### PR TITLE
Add branch alias for 1.0.x-dev and conflict with earlier versions of fractal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,13 @@
         "psr-4": {
             "League\\Fractal\\Test\\": "test"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
+    "conflict": {
+        "league/fractal": "<1.0"
     }
 }


### PR DESCRIPTION
Same story as https://github.com/thephpleague/fractal-serializer-jsonapi/pull/4